### PR TITLE
Make image tag required in examples and generate it automatically

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -58,8 +58,15 @@ jobs:
         with:
           submodules: false
       - name: Create tarball
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
         run: |
-          tar cf platform.tar README.md LICENSE examples/ 
+          # Replace "latest" version in examples
+          sed -i \
+            "s/^TENZIR_PLATFORM_VERSION=.*$/\TENZIR_PLATFORM_VERSION=${VERSION}/" \
+            examples/*/env.example
+          # Build deliverable
+          tar cf platform.tar README.md LICENSE examples/
       - name: Publish tarball to the GitHub Release
         if: ${{ github.event_name == 'release' }}
         uses: actions/upload-release-asset@v1

--- a/examples/localdev/docker-compose.yaml
+++ b/examples/localdev/docker-compose.yaml
@@ -9,7 +9,7 @@
 
 services:
   platform:
-    image: ghcr.io/tenzir/platform:${TENZIR_PLATFORM_VERSION:-latest}
+    image: ghcr.io/tenzir/platform:${TENZIR_PLATFORM_VERSION}
     command: ["tenant_manager/rest/server/local.py"]
     environment:
       - BASE_PATH=

--- a/examples/localdev/env.example
+++ b/examples/localdev/env.example
@@ -1,3 +1,7 @@
+# The docker image tag that is used for platform deployment
+# See https://ghcr.io/tenzir/platform
+TENZIR_PLATFORM_VERSION=latest
+
 # The `platform.local` placeholder domain needs to be
 # replaced by an ip or hostname under which the host running
 # the docker compose file is reachable.

--- a/examples/onprem/docker-compose.yaml
+++ b/examples/onprem/docker-compose.yaml
@@ -19,7 +19,7 @@
 
 services:
   platform:
-    image: ghcr.io/tenzir/platform:${TENZIR_PLATFORM_VERSION:-latest}
+    image: ghcr.io/tenzir/platform:${TENZIR_PLATFORM_VERSION}
     restart: unless-stopped
     command: ["tenant_manager/rest/server/local.py"]
     environment:

--- a/examples/onprem/env.example
+++ b/examples/onprem/env.example
@@ -1,3 +1,7 @@
+# The docker image tag that is used for platform deployment
+# See https://ghcr.io/tenzir/platform
+TENZIR_PLATFORM_VERSION=latest
+
 # The domain under which the platform frontend is reachable,
 # eg. `https://app.tenzir.example`
 # Must be routed to the `platform` service by the external HTTPS proxy.


### PR DESCRIPTION
https://github.com/tenzir/issues/issues/1938
### Reason for change
When users of the example are unaware that the `latest` tag is used by default, it could cause unintended updates.
### Solution
The version tag is now mandatory in the `.env` file to make users aware of its value. The user is forced to set it - removing it would cause an error. 
By default, its value is set to the version of the built image.