### PR TITLE
Improve login flow selection for the CLI

### DIFF
--- a/cli/tenzir_platform/helpers/oidc.py
+++ b/cli/tenzir_platform/helpers/oidc.py
@@ -162,7 +162,6 @@ class IdTokenClient:
             "audience": self.client_id,
         }
         credentials = base64.b64encode(f"{self.client_id}:{client_secret}".encode("utf-8")).decode("utf-8")
-        decoded_credentials = base64.b64decode(credentials).decode("utf-8")
         response = requests.post(
             self.token_endpoint,
             data=client_credentials_payload,


### PR DESCRIPTION
With this PR, the CLI will default to client credentials flow whenever a `CLIENT_SECRET` is present in the environment.

This makes it possible to use the CLI without a specific `login` step, which is particularly nice for the `localdev` setup.

Additionally, when using the client credentials flow, the id and secret information are now sent in an authorization header in additiona to the body, to achieve broader compatibility with existing OIDC providers.