### PR TITLE
Explicitly pass the commit hash to the frontend docker build

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -118,6 +118,8 @@ jobs:
       - name: Update app submodule
         run: |
           git submodule update --init components/app
+          app_commit=$(git -C components/app rev-parse HEAD)
+          echo "app_commit=$app_commit" >> $GITHUB_ENV
 
       - name: Configure ssh-agent for tenant-manager submodule
         uses: webfactory/ssh-agent@v0.9.0
@@ -174,6 +176,8 @@ jobs:
 
       - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build & push Docker image
+        env:
+          GIT_COMMIT_HASH: ${{ env.app_commit }}
         with:
           image: app
           tags: ${{ github.event.release.tag_name }},latest

--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -176,8 +176,6 @@ jobs:
 
       - uses: mr-smithers-excellent/docker-build-push@v6
         name: Build & push Docker image
-        env:
-          GIT_COMMIT_HASH: ${{ env.app_commit }}
         with:
           image: app
           tags: ${{ github.event.release.tag_name }},latest
@@ -186,3 +184,5 @@ jobs:
           dockerfile: components/app/Dockerfile
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          buildArgs:
+            - GIT_COMMIT_HASH=${{ env.app_commit }}

--- a/changelog/changes/IgnKODb1lbLsPzMZ7WgAltb8Oz.md
+++ b/changelog/changes/IgnKODb1lbLsPzMZ7WgAltb8Oz.md
@@ -1,0 +1,7 @@
+---
+title: "Explicitly pass the commit hash to the frontend docker build"
+type: bugfix
+authors: lava
+pr: 87
+---
+Fixed a bug where the git commit hash was shown as `unknown` in the app docker images.


### PR DESCRIPTION
When building the app from the platform repo, it does not contain a true `.git/` folder because it is only a submodule, and the build inside the Dockerfile also cannot access the top-level git dir because it is not mapped into the container. Thus it cannot figure out the current revision of HEAD.