### PR TITLE
Fix the platform release workflow configuration

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -184,5 +184,6 @@ jobs:
           dockerfile: components/app/Dockerfile
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          buildArgs:
-            - GIT_COMMIT_HASH=${{ env.app_commit }}
+
+          # Note: Comma-delimited string:
+          buildArgs: GIT_COMMIT_HASH=${{ env.app_commit }}


### PR DESCRIPTION
The buildArgs for mr-smithers-excellent/docker-build-push action are documented as a "List", but actually it's a comma-delimited string.