### PR TITLE
Revert the option to manually trigger the platform release workflow

### DIFF
--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -3,7 +3,6 @@ name: Create Sovereign Edition containers and also push a new production Cloud D
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions:
   packages: write


### PR DESCRIPTION
This reverts commit 52f16ebb4a24ee766e5384d9cc2d7d0051d73105 (pr #103)

It was never going to work, because the workflow relies on having access to release related context.