### PR TITLE
Fix proper platform docs path

### DIFF
--- a/docs/platform/cli.mdx
+++ b/docs/platform/cli.mdx
@@ -1,5 +1,7 @@
 ---
-title: Platform CLI
+title: Platform Command Line Interface
+sidebar:
+  label: Command Line Interface
 ---
 
 The _Tenzir Platform CLI_ allows users to interact with the _Tenzir Platform_


### PR DESCRIPTION
The `/reference` section at docs.tenzir.com recently got a new `/reference/platform` directory. This change adapts the local docs structure accordingly.
