### PR TITLE
Fix the main description in the changelog for the v1.14.1 release

### DIFF
--- a/changelog/releases/v1.14.1.yaml
+++ b/changelog/releases/v1.14.1.yaml
@@ -1,4 +1,4 @@
 title: Fix Pipelines Table
-description: We fixed a bug that prevented the table from scrolling when pipelines overflowed, so you can now access all rows without any being cut off.
+description: We resolved an issue where some rows in the pipelines table were being cut off. The table now scrolls properly when there are many entries.
 changes:
   - Nid5Sn0npWu12ZnplBsr95U4ME


### PR DESCRIPTION
Fix the main description in the changelog for the v1.14.1 release, as it currently shares the same text as the only entry in it, which makes it look like a bug