### PR TITLE
Add changelog entry for custom OIDC scope and audience params

### DIFF
--- a/changelog/changes/FRRXgavywEJHrtviHdxGz4SV4W.md
+++ b/changelog/changes/FRRXgavywEJHrtviHdxGz4SV4W.md
@@ -1,0 +1,8 @@
+---
+title: "Allow custom OIDC scope and audience params"
+type: feature
+authors: tobim
+pr: 127
+---
+
+Added support for customizing OIDC scope and audience parameters in the CLI to provide more flexibility in authentication configuration.


### PR DESCRIPTION
## Summary
- Added changelog entry for PR #127 which introduced support for custom OIDC scope and audience parameters
- Updated the description to clarify this is specifically for the CLI

## Test plan
- [x] Changelog entry follows the correct format
- [x] Entry includes proper metadata (author: tobim, PR: 127, type: feature)
- [x] Description clearly mentions this is a CLI feature